### PR TITLE
fix tf blocks

### DIFF
--- a/src/main/java/baguchan/tofucraft/blockentity/tfenergy/TFAggregatorBlockEntity.java
+++ b/src/main/java/baguchan/tofucraft/blockentity/tfenergy/TFAggregatorBlockEntity.java
@@ -95,7 +95,7 @@ public class TFAggregatorBlockEntity extends WorkerBaseBlockEntity implements Me
     };
 
     public TFAggregatorBlockEntity(BlockPos p_155229_, BlockState p_155230_) {
-        super(TofuBlockEntitys.TF_AGGREGATOR.get(), p_155229_, p_155230_, 50000);
+        super(TofuBlockEntitys.TF_AGGREGATOR.get(), p_155229_, p_155230_, 10000);
 
         this.inventory = createHandler();
         this.inputHandler = LazyOptional.of(() -> new TFOvenItemHandler(inventory, Direction.UP));

--- a/src/main/java/baguchan/tofucraft/blockentity/tfenergy/TFStorageBlockEntity.java
+++ b/src/main/java/baguchan/tofucraft/blockentity/tfenergy/TFStorageBlockEntity.java
@@ -105,7 +105,7 @@ public class TFStorageBlockEntity extends SenderBaseBlockEntity implements World
 
 		if (tfStorageBlockEntity.getEnergyStored() > 0) {
 			if (tfStorageBlockEntity.isValid()) {
-				if (!tfStorageBlockEntity.isCached || tfStorageBlockEntity.findCooldown <= 0)
+				if (!tfStorageBlockEntity.isCached || --tfStorageBlockEntity.findCooldown <= 0)
 					tfStorageBlockEntity.onCache();
 				if (tfStorageBlockEntity.cache.size() > 0) {
 					List<BlockEntity> toSend = new ArrayList<>();
@@ -121,7 +121,6 @@ public class TFStorageBlockEntity extends SenderBaseBlockEntity implements World
 							tfStorageBlockEntity.drain(((ITofuEnergy) te).receive(Math.min(packSize, tfStorageBlockEntity.getEnergyStored()), false), false);
 						}
 					}
-
 				}
 			} else {
 				tfStorageBlockEntity.cache.clear();

--- a/src/main/java/baguchan/tofucraft/blockentity/tfenergy/TFStorageBlockEntity.java
+++ b/src/main/java/baguchan/tofucraft/blockentity/tfenergy/TFStorageBlockEntity.java
@@ -100,8 +100,10 @@ public class TFStorageBlockEntity extends SenderBaseBlockEntity implements World
 		this.holder = LazyOptional.of(() -> this.tank);
 	}
 
-	public static void tick(Level level, BlockPos p_155015_, BlockState p_155016_, TFStorageBlockEntity tfStorageBlockEntity) {
-		if (!level.isClientSide() && tfStorageBlockEntity.getEnergyStored() > 0) {
+	public static void tick(Level level, BlockPos blockPos, BlockState blockState, TFStorageBlockEntity tfStorageBlockEntity) {
+		if (level.isClientSide()) return;
+
+		if (tfStorageBlockEntity.getEnergyStored() > 0) {
 			if (tfStorageBlockEntity.isValid()) {
 				if (!tfStorageBlockEntity.isCached || tfStorageBlockEntity.findCooldown <= 0)
 					tfStorageBlockEntity.onCache();
@@ -129,44 +131,38 @@ public class TFStorageBlockEntity extends SenderBaseBlockEntity implements World
 
 		boolean worked = false;
 
-		if (!level.isClientSide) {
-			if (tfStorageBlockEntity.prevFluid != tfStorageBlockEntity.tank.getFluidAmount()) {
-				LevelChunk chunk = level.getChunkAt(p_155015_);
-				TofuCraftReload.CHANNEL.send(PacketDistributor.TRACKING_CHUNK.with(() -> chunk), new TFStorageSoymilkMessage(p_155015_, tfStorageBlockEntity.tank.getFluid()));
-				tfStorageBlockEntity.prevFluid = tfStorageBlockEntity.tank.getFluidAmount();
+		//Transform workload to power
+		if (tfStorageBlockEntity.workload > 0 && tfStorageBlockEntity.getEnergyStored() < tfStorageBlockEntity.getMaxEnergyStored()) {
+			tfStorageBlockEntity.workload -= tfStorageBlockEntity.receive(Math.min(tfStorageBlockEntity.workload, POWER), false);
+			worked = true;
+		}
+		level.setBlock(blockPos, blockState.setValue(TFStorageBlock.LIT, worked), 3);
 
-
-				//Transform workload to power
-				if (tfStorageBlockEntity.workload > 0 && tfStorageBlockEntity.getEnergyStored() < tfStorageBlockEntity.getMaxEnergyStored()) {
-					tfStorageBlockEntity.workload -= tfStorageBlockEntity.receive(Math.min(tfStorageBlockEntity.workload, POWER), false);
-					worked = true;
-				}
-
-				//Consume beans inside machine
-				ItemStack from = tfStorageBlockEntity.inventory.get(0);
-				FluidStack milk = tfStorageBlockEntity.getTank().getFluid();
-				if (tfStorageBlockEntity.workload == 0) {
-					if (from.getItem() instanceof IEnergyExtractable) {
-						IEnergyExtractable symbol = (IEnergyExtractable) from.getItem();
-						tfStorageBlockEntity.workload += symbol.drain(from, POWER * 20, false);
-					} else if (TofuEnergyMap.getFuel(from) != -1) {
-						tfStorageBlockEntity.workload += TofuEnergyMap.getFuel(from);
-						from.shrink(1);
-					}
-
-					if (milk != null) {
-						Map.Entry<FluidStack, Integer> recipe = TofuEnergyMap.getLiquidFuel(milk);
-						if (recipe != null) {
-							tfStorageBlockEntity.tank.drain(recipe.getValue(), IFluidHandler.FluidAction.EXECUTE);
-							tfStorageBlockEntity.workload += recipe.getValue();
-						}
-					}
-					tfStorageBlockEntity.current_workload = tfStorageBlockEntity.workload;
-				}
-
-				final BlockState state = level.getBlockState(p_155015_);
-				level.setBlock(p_155015_, state.setValue(TFStorageBlock.LIT, worked), 3);
+		//Consume beans inside machine
+		if (tfStorageBlockEntity.workload == 0) {
+			ItemStack from = tfStorageBlockEntity.inventory.get(0);
+			FluidStack milk = tfStorageBlockEntity.getTank().getFluid();
+			if (from.getItem() instanceof IEnergyExtractable symbol) {
+				tfStorageBlockEntity.workload += symbol.drain(from, POWER * 20, false);
+			} else if (TofuEnergyMap.getFuel(from) != -1) {
+				tfStorageBlockEntity.workload += TofuEnergyMap.getFuel(from);
+				from.shrink(1);
 			}
+
+			if (!milk.isEmpty()) {
+				Map.Entry<FluidStack, Integer> recipe = TofuEnergyMap.getLiquidFuel(milk);
+				if (recipe != null) {
+					tfStorageBlockEntity.tank.drain(recipe.getValue(), IFluidHandler.FluidAction.EXECUTE);
+					tfStorageBlockEntity.workload += recipe.getValue();
+				}
+			}
+			tfStorageBlockEntity.current_workload = tfStorageBlockEntity.workload;
+		}
+
+		if (tfStorageBlockEntity.prevFluid != tfStorageBlockEntity.tank.getFluidAmount()) {
+			LevelChunk chunk = level.getChunkAt(blockPos);
+			TofuCraftReload.CHANNEL.send(PacketDistributor.TRACKING_CHUNK.with(() -> chunk), new TFStorageSoymilkMessage(blockPos, tfStorageBlockEntity.tank.getFluid()));
+			tfStorageBlockEntity.prevFluid = tfStorageBlockEntity.tank.getFluidAmount();
 		}
 	}
 


### PR DESCRIPTION
豆腐フォースのチャージ処理のデッドロック、エネルギー供給対象の捜索処理のクールダウンが一生終わらない、アグリケーターのエネルギー上限値がマイナスになる問題を修正しました。

詳しい内容は各コミットメッセージをご覧ください